### PR TITLE
Deploy in realease mode, add deploy on a separate branch on pull request

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,10 +33,8 @@ jobs:
       with:
         command: install
         args: --force trunk
-    # faster wasm target installer rather than rustup
-    - uses: jetli/wasm-pack-action@v0.3.0
-      with:
-        version: 'latest'
+    - run: |
+        rustup target add wasm32-unknown-unknown
     - run: |
         trunk build --release
       env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,8 +38,7 @@ jobs:
     - run: |
         rustup target add wasm32-unknown-unknown
     - run: |
-        trunk build
-      args: --release
+        trunk build --release
       env:
         TRUNK_BUILD_PUBLIC_URL: ./
     # Put the build in a branch for testing on pull requests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    types:
+    - opened
+    - reopened
+    branches:
+    - main
 
 jobs:
   deploy:
@@ -27,15 +33,24 @@ jobs:
       with:
         command: install
         args: --force trunk
-
+    # faster wasm target installer rather than rustup
+    - uses: jetli/wasm-pack-action@v0.3.0
+      with:
+        version: 'latest'
     - run: |
-        rustup target add wasm32-unknown-unknown
-    - run: |
-        trunk build
+        trunk build --release
       env:
         TRUNK_BUILD_PUBLIC_URL: ./
-    - uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
+    # Put the build in a branch for testing on pull requests
+    - if: github.event_name == 'pull_request'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages-pr-test
+        publish_dir: ./dist
+    # Put the build gh pages public branch on main push/pr merge
+    - if: github.event_name == 'push'
+      uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,8 @@ jobs:
     - run: |
         rustup target add wasm32-unknown-unknown
     - run: |
-        trunk build --release
+        trunk build
+      args: --release
       env:
         TRUNK_BUILD_PUBLIC_URL: ./
     # Put the build in a branch for testing on pull requests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
     - opened
+    - edited
     - reopened
     branches:
     - main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ on:
     types:
     - opened
     - edited
+    - synchronize
     - reopened
     branches:
     - main


### PR DESCRIPTION
- Fix bad performance experienced on gh pages caused by building the app as debug mode(whoops)
- For PR testing on gh pages build results, the webapp should be deployed in gh-pages-pr-test branch on a PR